### PR TITLE
AmortisationsrechnerPV - Layout + Funktion

### DIFF
--- a/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVFragment.kt
+++ b/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVFragment.kt
@@ -8,13 +8,11 @@ import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
 import com.example.stromtracker.R
 
 
 class AmortisationsrechnerPVFragment : Fragment() {
 
-    private lateinit var amortisationsrechnerPVViewModel: AmortisationsrechnerPVViewModel
     private lateinit var editLeistung: EditText
     private lateinit var editAK: EditText
     private lateinit var outJahresertragkWh: TextView
@@ -28,8 +26,6 @@ class AmortisationsrechnerPVFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        amortisationsrechnerPVViewModel =
-            ViewModelProviders.of(this).get(com.example.stromtracker.ui.amortisationsrechnerPV.AmortisationsrechnerPVViewModel::class.java)
         val root = inflater.inflate(R.layout.fragment_amortisationsrechnerpv, container, false)
 
         editLeistung = root.findViewById(R.id.amortPV_edit_leistung)
@@ -38,7 +34,7 @@ class AmortisationsrechnerPVFragment : Fragment() {
         outJahresertragEuro= root.findViewById(R.id.amortPV_text_JahresertragEuro_zahl)
         outAmort = root.findViewById(R.id.amortPV_text_amortdauer_zahl)
 
-        //Hier wird der Jahresertrag in kWh jedes mal berechnet, wenn sich der Text des Leistungsinputs ändert
+        //Hier wird der Jahresertrag in kWh und in Euro jedes mal berechnet, wenn sich der Text des Leistungsinputs ändert
         editLeistung.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable) {
                 val leistung:Double? = editLeistung.text.toString().toDoubleOrNull()
@@ -46,6 +42,12 @@ class AmortisationsrechnerPVFragment : Fragment() {
                     outJahresertragkWh.text = (leistung * durchschnittErtragDE).toInt().toString()
                     val JEeuro : Double = (leistung * durchschnittErtragDE * durchschnittVerguetungDE)
                     outJahresertragEuro.text = String.format("%.2f", JEeuro)
+                    val AK:Int? = editAK.text.toString().toIntOrNull()
+                    if(AK!=null) {
+                        val amortDouble = (AK / (leistung * durchschnittErtragDE * durchschnittVerguetungDE))
+                        //Ausgabe mit 3 Nachkommastellen
+                        outAmort.text = String.format("%.3f", amortDouble)
+                    }
                 }
                 else {
                     outJahresertragkWh.text = null
@@ -56,6 +58,7 @@ class AmortisationsrechnerPVFragment : Fragment() {
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) { }
         })
 
+        //Hier wird die Amortisationsdauer jedes mal berechnet, wenn sich der Text des Leistungsinputs ändert
         editAK.addTextChangedListener(object : TextWatcher {
             override fun afterTextChanged(s: Editable) {
                 val AK:Int? = editAK.text.toString().toIntOrNull()

--- a/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVFragment.kt
+++ b/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVFragment.kt
@@ -1,18 +1,27 @@
 package com.example.stromtracker.ui.amortisationsrechnerPV
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.example.stromtracker.R
-import com.example.stromtracker.ui.amortisationsrechnerPV.AmortisationsrechnerPVViewModel
+
 
 class AmortisationsrechnerPVFragment : Fragment() {
 
     private lateinit var amortisationsrechnerPVViewModel: AmortisationsrechnerPVViewModel
+    private lateinit var editLeistung: EditText
+    private lateinit var editAK: EditText
+    private lateinit var outJahresertragkWh: TextView
+    private lateinit var outJahresertragEuro: TextView
+    private lateinit var outAmort: TextView
+    private val durchschnittErtragDE = 910 //kWh pro Jahr pro kWp
+    private val durchschnittVerguetungDE : Double = 0.0903 // Ct/kWh Ab 01.07.2020 bis 10kWP
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -22,6 +31,47 @@ class AmortisationsrechnerPVFragment : Fragment() {
         amortisationsrechnerPVViewModel =
             ViewModelProviders.of(this).get(com.example.stromtracker.ui.amortisationsrechnerPV.AmortisationsrechnerPVViewModel::class.java)
         val root = inflater.inflate(R.layout.fragment_amortisationsrechnerpv, container, false)
+
+        editLeistung = root.findViewById(R.id.amortPV_edit_leistung)
+        editAK = root.findViewById(R.id.amortPV_edit_anschaffung)
+        outJahresertragkWh = root.findViewById(R.id.amortPV_text_jahresertragkWh_zahl)
+        outJahresertragEuro= root.findViewById(R.id.amortPV_text_JahresertragEuro_zahl)
+        outAmort = root.findViewById(R.id.amortPV_text_amortdauer_zahl)
+
+        //Hier wird der Jahresertrag in kWh jedes mal berechnet, wenn sich der Text des Leistungsinputs ändert
+        editLeistung.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable) {
+                val leistung:Double? = editLeistung.text.toString().toDoubleOrNull()
+                if(leistung != null) {
+                    outJahresertragkWh.text = (leistung * durchschnittErtragDE).toInt().toString()
+                    val JEeuro : Double = (leistung * durchschnittErtragDE * durchschnittVerguetungDE)
+                    outJahresertragEuro.text = String.format("%.2f", JEeuro)
+                }
+                else {
+                    outJahresertragkWh.text = null
+                    outJahresertragEuro.text = null
+                }
+            }
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) { }
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) { }
+        })
+
+        editAK.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable) {
+                val AK:Int? = editAK.text.toString().toIntOrNull()
+                val leistung:Double? = editLeistung.text.toString().toDoubleOrNull()
+                if(AK != null)
+                    if (leistung != null) {
+                        val amortDouble = (AK / (leistung * durchschnittErtragDE * durchschnittVerguetungDE))
+                        //Ausgabe mit 3 Nachkommastellen
+                        outAmort.text = String.format("%.3f", amortDouble)
+                    }
+                else
+                    outAmort.text = null
+            }
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) { }
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) { }
+        })
 
         return root
     }

--- a/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVFragment.kt
+++ b/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVFragment.kt
@@ -22,10 +22,7 @@ class AmortisationsrechnerPVFragment : Fragment() {
         amortisationsrechnerPVViewModel =
             ViewModelProviders.of(this).get(com.example.stromtracker.ui.amortisationsrechnerPV.AmortisationsrechnerPVViewModel::class.java)
         val root = inflater.inflate(R.layout.fragment_amortisationsrechnerpv, container, false)
-        val textView: TextView = root.findViewById(R.id.text_amortisationsrechnerPV)
-        amortisationsrechnerPVViewModel.text.observe(viewLifecycleOwner, Observer {
-            textView.text = it
-        })
+
         return root
     }
 }

--- a/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVViewModel.kt
+++ b/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVViewModel.kt
@@ -1,9 +1,0 @@
-package com.example.stromtracker.ui.amortisationsrechnerPV
-
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-
-class AmortisationsrechnerPVViewModel : ViewModel() {
-
-}

--- a/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVViewModel.kt
+++ b/app/src/main/java/com/example/stromtracker/ui/amortisationsrechnerPV/AmortisationsrechnerPVViewModel.kt
@@ -5,8 +5,5 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 class AmortisationsrechnerPVViewModel : ViewModel() {
-    private val _text = MutableLiveData<String>().apply {
-        value = "This is AmortisationsPV Fragment"
-    }
-    val text: LiveData<String> = _text
+
 }

--- a/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
+++ b/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
@@ -134,12 +134,13 @@
                 android:layout_marginTop="24dp"
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
-                android:text="@string/amportPV_text_amortdauer"
+                android:text="@string/amortPV_text_amortdauer"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertrag_beschreibung"
                 app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertrag_beschreibung" />
 
             <androidx.cardview.widget.CardView
+                android:id="@+id/cardView2"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
@@ -155,6 +156,15 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/amortPV_hint_amortdauer_zahl" />
             </androidx.cardview.widget.CardView>
+
+            <TextView
+                android:id="@+id/amortPV_text_amortdauer_beschreibung"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/amortPV_text_amortdauer_beschreibung"
+                app:layout_constraintStart_toStartOf="@+id/cardView2"
+                app:layout_constraintTop_toBottomOf="@+id/cardView2" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
+++ b/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
@@ -91,41 +91,72 @@
                 android:autofillHints="@string/amortPV_hint_anschaffung" />
 
             <TextView
-                android:id="@+id/amortPV_text_jahresertrag"
+                android:id="@+id/amortPV_text_jahresertragkWh"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
-                android:text="@string/amortPV_text_jahresertrag"
+                android:text="@string/amortPV_text_jahresertragkWh"
                 app:layout_constraintEnd_toEndOf="@+id/amortPV_text_anschaffung"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="@+id/amortPV_edit_anschaffung"
                 app:layout_constraintTop_toBottomOf="@+id/amortPV_edit_anschaffung" />
 
             <androidx.cardview.widget.CardView
-                android:id="@+id/cardView"
+                android:id="@+id/amortPV_card_jahresertragkWh"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_jahresertrag"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertrag"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertrag">
+                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_jahresertragkWh"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragkWh">
 
                 <TextView
-                    android:id="@+id/amortPV_text_jahresertrag_zahl"
+                    android:id="@+id/amortPV_text_jahresertragkWh_zahl"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:hint="@string/amortPV_hint_jahresertrag_zahl" />
+                    android:hint="@string/amortPV_hint_jahresertragkWh_zahl" />
             </androidx.cardview.widget.CardView>
 
             <TextView
-                android:id="@+id/amortPV_text_jahresertrag_beschreibung"
+                android:id="@+id/amortPV_text_jahresertragkWh_beschreibung"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="@string/amortPV_text_jahresertrag_beschreibung"
-                app:layout_constraintEnd_toEndOf="@+id/cardView"
-                app:layout_constraintStart_toStartOf="@+id/cardView"
-                app:layout_constraintTop_toBottomOf="@+id/cardView" />
+                android:text="@string/amortPV_text_jahresertragkWh_beschreibung"
+                app:layout_constraintEnd_toEndOf="@+id/amortPV_card_jahresertragkWh"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_card_jahresertragkWh"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragkWh" />
+
+            <TextView
+                android:id="@+id/amortPV_text_jahresertragEuro"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:text="@string/amortPV_text_jahresertragEuro"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragkWh_beschreibung" />
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/amortPV_card_jahresertragEuro"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragEuro"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragEuro">
+
+                <TextView
+                    android:id="@+id/amortPV_text_JahresertragEuro_zahl"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/amortPV_hint_jahresertragEuro_zahl"/>
+            </androidx.cardview.widget.CardView>
 
             <TextView
                 android:id="@+id/amortPV_text_amortdauer"
@@ -136,11 +167,11 @@
                 android:layout_marginRight="8dp"
                 android:text="@string/amortPV_text_amortdauer"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertrag_beschreibung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertrag_beschreibung" />
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragEuro" />
 
             <androidx.cardview.widget.CardView
-                android:id="@+id/cardView2"
+                android:id="@+id/amortPV_card_amortdauer"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
@@ -159,12 +190,15 @@
 
             <TextView
                 android:id="@+id/amortPV_text_amortdauer_beschreibung"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
                 android:text="@string/amortPV_text_amortdauer_beschreibung"
-                app:layout_constraintStart_toStartOf="@+id/cardView2"
-                app:layout_constraintTop_toBottomOf="@+id/cardView2" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_card_amortdauer"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_card_amortdauer" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
+++ b/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
@@ -8,200 +8,204 @@
     tools:context=".ui.amortisationsrechnerPV.AmortisationsrechnerPVFragment">
 
 
-    <androidx.cardview.widget.CardView
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginStart="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginBottom="16dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_height="match_parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.cardview.widget.CardView
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginRight="16dp"
+            android:layout_marginBottom="16dp">
 
-            <TextView
-                android:id="@+id/amortPV_text_beschreibung"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginLeft="8dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:text="@string/amortPV_text_beschreibung"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/amortPV_text_leistung"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:text="@string/amortPV_text_leistung"
-                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_beschreibung"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_beschreibung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_beschreibung" />
-
-            <EditText
-                android:id="@+id/amortPV_edit_leistung"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="305dp"
-                android:layout_marginRight="305dp"
-                android:hint="@string/amortPV_hint_leistung"
-                android:inputType="numberDecimal"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_leistung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_leistung"
-                android:autofillHints="@string/amortPV_hint_leistung" />
-
-            <TextView
-                android:id="@+id/amortPV_text_anschaffung"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:text="@string/amortPV_text_anschaffung"
-                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_leistung"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_edit_leistung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_edit_leistung" />
-
-            <EditText
-                android:id="@+id/amortPV_edit_anschaffung"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="282dp"
-                android:layout_marginRight="282dp"
-                android:hint="@string/amortPV_hint_anschaffung"
-                android:inputType="number"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_anschaffung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_anschaffung"
-                android:autofillHints="@string/amortPV_hint_anschaffung" />
-
-            <TextView
-                android:id="@+id/amortPV_text_jahresertragkWh"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:text="@string/amortPV_text_jahresertragkWh"
-                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_anschaffung"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_edit_anschaffung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_edit_anschaffung" />
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/amortPV_card_jahresertragkWh"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_jahresertragkWh"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragkWh">
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
                 <TextView
-                    android:id="@+id/amortPV_text_jahresertragkWh_zahl"
-                    android:layout_width="wrap_content"
+                    android:id="@+id/amortPV_text_beschreibung"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:hint="@string/amortPV_hint_jahresertragkWh_zahl" />
-            </androidx.cardview.widget.CardView>
-
-            <TextView
-                android:id="@+id/amortPV_text_jahresertragkWh_beschreibung"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:text="@string/amortPV_text_jahresertragkWh_beschreibung"
-                app:layout_constraintEnd_toEndOf="@+id/amortPV_card_jahresertragkWh"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_card_jahresertragkWh"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragkWh" />
-
-            <TextView
-                android:id="@+id/amortPV_text_jahresertragEuro"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:text="@string/amortPV_text_jahresertragEuro"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragkWh_beschreibung" />
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/amortPV_card_jahresertragEuro"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragEuro"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragEuro">
+                    android:layout_marginStart="8dp"
+                    android:layout_marginLeft="8dp"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:text="@string/amortPV_text_beschreibung"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <TextView
-                    android:id="@+id/amortPV_text_JahresertragEuro_zahl"
+                    android:id="@+id/amortPV_text_leistung"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/amortPV_text_leistung"
+                    app:layout_constraintEnd_toEndOf="@+id/amortPV_text_beschreibung"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_beschreibung"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_text_beschreibung" />
+
+                <EditText
+                    android:id="@+id/amortPV_edit_leistung"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:hint="@string/amortPV_hint_jahresertragEuro_zahl"/>
-            </androidx.cardview.widget.CardView>
-
-            <TextView
-                android:id="@+id/amortPV_text_amortdauer"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:text="@string/amortPV_text_amortdauer"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragEuro" />
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/amortPV_card_amortdauer"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_text_amortdauer"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_amortdauer">
+                    android:layout_marginEnd="305dp"
+                    android:layout_marginRight="305dp"
+                    android:autofillHints="@string/amortPV_hint_leistung"
+                    android:hint="@string/amortPV_hint_leistung"
+                    android:inputType="numberDecimal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_leistung"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_text_leistung" />
 
                 <TextView
-                    android:id="@+id/amortPV_text_amortdauer_zahl"
+                    android:id="@+id/amortPV_text_anschaffung"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/amortPV_text_anschaffung"
+                    app:layout_constraintEnd_toEndOf="@+id/amortPV_text_leistung"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_edit_leistung"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_edit_leistung" />
+
+                <EditText
+                    android:id="@+id/amortPV_edit_anschaffung"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:hint="@string/amortPV_hint_amortdauer_zahl" />
-            </androidx.cardview.widget.CardView>
+                    android:layout_marginEnd="282dp"
+                    android:layout_marginRight="282dp"
+                    android:autofillHints="@string/amortPV_hint_anschaffung"
+                    android:hint="@string/amortPV_hint_anschaffung"
+                    android:inputType="number"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_anschaffung"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_text_anschaffung" />
 
-            <TextView
-                android:id="@+id/amortPV_text_amortdauer_beschreibung"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:text="@string/amortPV_text_amortdauer_beschreibung"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/amortPV_card_amortdauer"
-                app:layout_constraintTop_toBottomOf="@+id/amortPV_card_amortdauer" />
+                <TextView
+                    android:id="@+id/amortPV_text_jahresertragkWh"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/amortPV_text_jahresertragkWh"
+                    app:layout_constraintEnd_toEndOf="@+id/amortPV_text_anschaffung"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_edit_anschaffung"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_edit_anschaffung" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/amortPV_card_jahresertragkWh"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="@+id/amortPV_text_jahresertragkWh"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragkWh">
 
-    </androidx.cardview.widget.CardView>
+                    <TextView
+                        android:id="@+id/amortPV_text_jahresertragkWh_zahl"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/amortPV_hint_jahresertragkWh_zahl" />
+                </androidx.cardview.widget.CardView>
+
+                <TextView
+                    android:id="@+id/amortPV_text_jahresertragkWh_beschreibung"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/amortPV_text_jahresertragkWh_beschreibung"
+                    app:layout_constraintEnd_toEndOf="@+id/amortPV_card_jahresertragkWh"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_card_jahresertragkWh"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragkWh" />
+
+                <TextView
+                    android:id="@+id/amortPV_text_jahresertragEuro"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:text="@string/amortPV_text_jahresertragEuro"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragkWh_beschreibung" />
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/amortPV_card_jahresertragEuro"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragEuro"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertragEuro">
+
+                    <TextView
+                        android:id="@+id/amortPV_text_JahresertragEuro_zahl"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/amortPV_hint_jahresertragEuro_zahl" />
+                </androidx.cardview.widget.CardView>
+
+                <TextView
+                    android:id="@+id/amortPV_text_amortdauer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:text="@string/amortPV_text_amortdauer"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragEuro" />
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/amortPV_card_amortdauer"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_text_amortdauer"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_text_amortdauer">
+
+                    <TextView
+                        android:id="@+id/amortPV_text_amortdauer_zahl"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/amortPV_hint_amortdauer_zahl" />
+                </androidx.cardview.widget.CardView>
+
+                <TextView
+                    android:id="@+id/amortPV_text_amortdauer_beschreibung"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:layout_marginBottom="16dp"
+                    android:text="@string/amortPV_text_amortdauer_beschreibung"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/amortPV_card_amortdauer"
+                    app:layout_constraintTop_toBottomOf="@+id/amortPV_card_amortdauer" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.cardview.widget.CardView>
+    </ScrollView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
+++ b/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
@@ -36,6 +36,7 @@
                     android:layout_marginEnd="8dp"
                     android:layout_marginRight="8dp"
                     android:text="@string/amortPV_text_beschreibung"
+                    android:textSize="@dimen/content_text_big"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="parent"
@@ -47,6 +48,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:text="@string/amortPV_text_leistung"
+                    android:textSize="@dimen/content_text_normal"
                     app:layout_constraintEnd_toEndOf="@+id/amortPV_text_beschreibung"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_text_beschreibung"
@@ -61,6 +63,7 @@
                     android:autofillHints="@string/amortPV_hint_leistung"
                     android:hint="@string/amortPV_hint_leistung"
                     android:inputType="numberDecimal"
+                    android:textSize="@dimen/content_text_big"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_text_leistung"
@@ -72,6 +75,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:text="@string/amortPV_text_anschaffung"
+                    android:textSize="@dimen/content_text_normal"
                     app:layout_constraintEnd_toEndOf="@+id/amortPV_text_leistung"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_edit_leistung"
@@ -86,6 +90,7 @@
                     android:autofillHints="@string/amortPV_hint_anschaffung"
                     android:hint="@string/amortPV_hint_anschaffung"
                     android:inputType="number"
+                    android:textSize="@dimen/content_text_big"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_text_anschaffung"
@@ -97,6 +102,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:text="@string/amortPV_text_jahresertragkWh"
+                    android:textSize="@dimen/content_text_normal"
                     app:layout_constraintEnd_toEndOf="@+id/amortPV_text_anschaffung"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_edit_anschaffung"
@@ -115,7 +121,8 @@
                         android:id="@+id/amortPV_text_jahresertragkWh_zahl"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:hint="@string/amortPV_hint_jahresertragkWh_zahl" />
+                        android:hint="@string/amortPV_hint_jahresertragkWh_zahl"
+                        android:textSize="@dimen/content_text_big"/>
                 </androidx.cardview.widget.CardView>
 
                 <TextView
@@ -124,6 +131,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/amortPV_text_jahresertragkWh_beschreibung"
+                    android:textSize="@dimen/content_text_smaller"
                     app:layout_constraintEnd_toEndOf="@+id/amortPV_card_jahresertragkWh"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_card_jahresertragkWh"
                     app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragkWh" />
@@ -136,6 +144,7 @@
                     android:layout_marginEnd="8dp"
                     android:layout_marginRight="8dp"
                     android:text="@string/amortPV_text_jahresertragEuro"
+                    android:textSize="@dimen/content_text_normal"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
@@ -156,7 +165,8 @@
                         android:id="@+id/amortPV_text_JahresertragEuro_zahl"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:hint="@string/amortPV_hint_jahresertragEuro_zahl" />
+                        android:hint="@string/amortPV_hint_jahresertragEuro_zahl"
+                        android:textSize="@dimen/content_text_big"/>
                 </androidx.cardview.widget.CardView>
 
                 <TextView
@@ -167,6 +177,7 @@
                     android:layout_marginEnd="8dp"
                     android:layout_marginRight="8dp"
                     android:text="@string/amortPV_text_amortdauer"
+                    android:textSize="@dimen/content_text_normal"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertragkWh_beschreibung"
                     app:layout_constraintTop_toBottomOf="@+id/amortPV_card_jahresertragEuro" />
@@ -186,7 +197,8 @@
                         android:id="@+id/amortPV_text_amortdauer_zahl"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:hint="@string/amortPV_hint_amortdauer_zahl" />
+                        android:hint="@string/amortPV_hint_amortdauer_zahl"
+                        android:textSize="@dimen/content_text_big"/>
                 </androidx.cardview.widget.CardView>
 
                 <TextView
@@ -198,6 +210,7 @@
                     android:layout_marginRight="8dp"
                     android:layout_marginBottom="16dp"
                     android:text="@string/amortPV_text_amortdauer_beschreibung"
+                    android:textSize="@dimen/content_text_smaller"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@+id/amortPV_card_amortdauer"

--- a/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
+++ b/app/src/main/res/layout/fragment_amortisationsrechnerpv.xml
@@ -4,20 +4,160 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/colorBackgroundGrey"
     tools:context=".ui.amortisationsrechnerPV.AmortisationsrechnerPVFragment">
 
-    <TextView
-        android:id="@+id/text_amortisationsrechnerPV"
+
+    <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_height="match_parent"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_gravity="center_horizontal" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/amortPV_text_beschreibung"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:text="@string/amortPV_text_beschreibung"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/amortPV_text_leistung"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/amortPV_text_leistung"
+                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_beschreibung"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_beschreibung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_beschreibung" />
+
+            <EditText
+                android:id="@+id/amortPV_edit_leistung"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="305dp"
+                android:layout_marginRight="305dp"
+                android:hint="@string/amortPV_hint_leistung"
+                android:inputType="numberDecimal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_leistung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_leistung"
+                android:autofillHints="@string/amortPV_hint_leistung" />
+
+            <TextView
+                android:id="@+id/amortPV_text_anschaffung"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/amortPV_text_anschaffung"
+                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_leistung"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_edit_leistung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_edit_leistung" />
+
+            <EditText
+                android:id="@+id/amortPV_edit_anschaffung"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="282dp"
+                android:layout_marginRight="282dp"
+                android:hint="@string/amortPV_hint_anschaffung"
+                android:inputType="number"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_anschaffung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_anschaffung"
+                android:autofillHints="@string/amortPV_hint_anschaffung" />
+
+            <TextView
+                android:id="@+id/amortPV_text_jahresertrag"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/amortPV_text_jahresertrag"
+                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_anschaffung"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_edit_anschaffung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_edit_anschaffung" />
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/cardView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                app:layout_constraintEnd_toEndOf="@+id/amortPV_text_jahresertrag"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertrag"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertrag">
+
+                <TextView
+                    android:id="@+id/amortPV_text_jahresertrag_zahl"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/amortPV_hint_jahresertrag_zahl" />
+            </androidx.cardview.widget.CardView>
+
+            <TextView
+                android:id="@+id/amortPV_text_jahresertrag_beschreibung"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/amortPV_text_jahresertrag_beschreibung"
+                app:layout_constraintEnd_toEndOf="@+id/cardView"
+                app:layout_constraintStart_toStartOf="@+id/cardView"
+                app:layout_constraintTop_toBottomOf="@+id/cardView" />
+
+            <TextView
+                android:id="@+id/amortPV_text_amortdauer"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:text="@string/amportPV_text_amortdauer"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_jahresertrag_beschreibung"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_jahresertrag_beschreibung" />
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/amortPV_text_amortdauer"
+                app:layout_constraintTop_toBottomOf="@+id/amortPV_text_amortdauer">
+
+                <TextView
+                    android:id="@+id/amortPV_text_amortdauer_zahl"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/amortPV_hint_amortdauer_zahl" />
+            </androidx.cardview.widget.CardView>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.cardview.widget.CardView>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,4 +5,10 @@
     <dimen name="nav_header_vertical_spacing">8dp</dimen>
     <dimen name="nav_header_height">176dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
+
+
+    <dimen name="content_text_big">18sp</dimen>
+    <dimen name="content_text_normal">16sp</dimen>
+    <dimen name="content_text_small">14sp</dimen>
+    <dimen name="content_text_smaller">12sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,9 +52,9 @@
 
     <string name="amortPV_hint_leistung">z.B. 4.5</string>
     <string name="amortPV_hint_anschaffung">z.B. 6525</string>
-    <string name="amortPV_hint_jahresertragkWh_zahl">z.B. 4550</string>
-    <string name="amortPV_hint_amortdauer_zahl">z.B. 741</string>
-    <string name="amortPV_hint_jahresertragEuro_zahl">z.B. 1111.57</string>
+    <string name="amortPV_hint_jahresertragkWh_zahl">z.B. 4095</string>
+    <string name="amortPV_hint_amortdauer_zahl">z.B. 17.6</string>
+    <string name="amortPV_hint_jahresertragEuro_zahl">z.B. 369.78</string>
     <string name="amortPV_text_beschreibung">Vereinfachte Bestimmung der Amortisationszeit für eine Photovoltaik-Anlage</string>
     <string name="amortPV_text_leistung">Leistung der PV-Anlage in kWp</string>
     <string name="amortPV_text_anschaffung">Anschaffungskosten in Euro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,13 +53,14 @@
     <string name="amortPV_hint_leistung">z.B. 4.5</string>
     <string name="amortPV_hint_anschaffung">z.B. 6525</string>
     <string name="amortPV_hint_jahresertrag_zahl">z.B. 4550kWh</string>
+    <string name="amortPV_hint_amortdauer_zahl">z.B. 741 Tage</string>
     <string name="amortPV_text_beschreibung">Vereinfachte Bestimmung der Amortisationszeit für eine Photovoltaik-Anlage</string>
     <string name="amortPV_text_leistung">Wie hoch ist die Leistung der PV-Anlage in kWp?</string>
     <string name="amortPV_text_anschaffung">Anschaffungskosten in Euro</string>
-    <string name="amortPV_text_jahresertrag">Jahresertrag</string>
+    <string name="amortPV_text_jahresertrag">Jahresertrag in kWh</string>
     <string name="amortPV_text_jahresertrag_beschreibung">(durchschnittlicher Ertrag pro kWp in Deutschland * Leistung der PV in kWp)</string>
-    <string name="amportPV_text_amortdauer">Amortisationsdauer</string>
-    <string name="amortPV_hint_amortdauer_zahl">z.B. 741 Tage</string>
+    <string name="amortPV_text_amortdauer">Amortisationsdauer in Tagen</string>
+    <string name="amortPV_text_amortdauer_beschreibung">(basierend auf einer Vergütung von 9.03 Cent/kWh, Stand: Juli 2020)</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,16 @@
     <string name="haushaltedithint_strommix">80 für 80%</string>
     <string name="haushaltlöschenConfirm">Sind sie sicher, dass sie den Hauhalt löschen wollen?</string>
 
+    <string name="amortPV_hint_leistung">z.B. 4.5</string>
+    <string name="amortPV_hint_anschaffung">z.B. 6525</string>
+    <string name="amortPV_hint_jahresertrag_zahl">z.B. 4550kWh</string>
+    <string name="amortPV_text_beschreibung">Vereinfachte Bestimmung der Amortisationszeit für eine Photovoltaik-Anlage</string>
+    <string name="amortPV_text_leistung">Wie hoch ist die Leistung der PV-Anlage in kWp?</string>
+    <string name="amortPV_text_anschaffung">Anschaffungskosten in Euro</string>
+    <string name="amortPV_text_jahresertrag">Jahresertrag</string>
+    <string name="amortPV_text_jahresertrag_beschreibung">(durchschnittlicher Ertrag pro kWp in Deutschland * Leistung der PV in kWp)</string>
+    <string name="amportPV_text_amortdauer">Amortisationsdauer</string>
+    <string name="amortPV_hint_amortdauer_zahl">z.B. 741 Tage</string>
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,15 +52,17 @@
 
     <string name="amortPV_hint_leistung">z.B. 4.5</string>
     <string name="amortPV_hint_anschaffung">z.B. 6525</string>
-    <string name="amortPV_hint_jahresertrag_zahl">z.B. 4550kWh</string>
-    <string name="amortPV_hint_amortdauer_zahl">z.B. 741 Tage</string>
+    <string name="amortPV_hint_jahresertragkWh_zahl">z.B. 4550</string>
+    <string name="amortPV_hint_amortdauer_zahl">z.B. 741</string>
+    <string name="amortPV_hint_jahresertragEuro_zahl">z.B. 1111.57</string>
     <string name="amortPV_text_beschreibung">Vereinfachte Bestimmung der Amortisationszeit für eine Photovoltaik-Anlage</string>
-    <string name="amortPV_text_leistung">Wie hoch ist die Leistung der PV-Anlage in kWp?</string>
+    <string name="amortPV_text_leistung">Leistung der PV-Anlage in kWp</string>
     <string name="amortPV_text_anschaffung">Anschaffungskosten in Euro</string>
-    <string name="amortPV_text_jahresertrag">Jahresertrag in kWh</string>
-    <string name="amortPV_text_jahresertrag_beschreibung">(durchschnittlicher Ertrag pro kWp in Deutschland * Leistung der PV in kWp)</string>
-    <string name="amortPV_text_amortdauer">Amortisationsdauer in Tagen</string>
+    <string name="amortPV_text_jahresertragkWh">Jahresertrag in kWh</string>
+    <string name="amortPV_text_jahresertragkWh_beschreibung">(durchschnittlicher Ertrag pro kWp in Deutschland * Leistung der PV in kWp)</string>
+    <string name="amortPV_text_amortdauer">Amortisationsdauer in Jahren</string>
     <string name="amortPV_text_amortdauer_beschreibung">(basierend auf einer Vergütung von 9.03 Cent/kWh, Stand: Juli 2020)</string>
+    <string name="amortPV_text_jahresertragEuro">Jahresertrag in Euro</string>
 
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <string name="amortPV_text_leistung">Leistung der PV-Anlage in kWp</string>
     <string name="amortPV_text_anschaffung">Anschaffungskosten in Euro</string>
     <string name="amortPV_text_jahresertragkWh">Jahresertrag in kWh</string>
-    <string name="amortPV_text_jahresertragkWh_beschreibung">(durchschnittlicher Ertrag pro kWp in Deutschland * Leistung der PV in kWp)</string>
+    <string name="amortPV_text_jahresertragkWh_beschreibung">(basierend auf durchschnittlichem Ertrag in Deutschland von 910kWh pro 1kWp im Jahr, Stand: Juli 2020)</string>
     <string name="amortPV_text_amortdauer">Amortisationsdauer in Jahren</string>
     <string name="amortPV_text_amortdauer_beschreibung">(basierend auf einer Vergütung von 9.03 Cent/kWh, Stand: Juli 2020)</string>
     <string name="amortPV_text_jahresertragEuro">Jahresertrag in Euro</string>


### PR DESCRIPTION
Das AmortisationsrechnerPV Fragment wurde bearbeitet.
Nun enthält es das passende Layout mit Funktionalität.
Die Vergütung pro kWh und die durchschnittlichen kWh pro kWp im Jahr sind in der Klasse AmortisationsrechnerPVFrament als Konstanten festgelegt.
Ändert man die Eingabe an einem der beiden Textfelder, so werden automatisch Jahresertrag in kWh / Euro und die Amortisationsdauer in Jahren berechnet.

Das ViewModel von AmortisationsrechnerPV wurde gelöscht, weil es nicht benötigt wird.