### PR TITLE
Haushalt Zählerstand into Develop

### DIFF
--- a/app/src/main/java/com/example/stromtracker/ui/haushalt/HaushaltViewModel.kt
+++ b/app/src/main/java/com/example/stromtracker/ui/haushalt/HaushaltViewModel.kt
@@ -3,9 +3,7 @@ package com.example.stromtracker.ui.haushalt
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
-import com.example.stromtracker.database.DataRepository
-import com.example.stromtracker.database.Haushalt
-import com.example.stromtracker.database.Raum
+import com.example.stromtracker.database.*
 
 class HaushaltViewModel(application: Application) : AndroidViewModel(application) {
     private var repo: DataRepository = DataRepository(application)
@@ -13,6 +11,18 @@ class HaushaltViewModel(application: Application) : AndroidViewModel(application
 
     fun getAllHaushalt(): LiveData<List<Haushalt>> {
         return haushaltList
+    }
+
+    fun getAllVerbraucherByHaushaltID(id: Int): LiveData<List<Geraete>> {
+        return repo.getAllVerbraucherByHaushaltID(id)
+    }
+
+    fun getAllProduzentenByHaushaltID(id: Int): LiveData<List<Geraete>> {
+        return repo.getAllProduzentenByHaushaltID(id)
+    }
+
+    fun getAllUrlaubByHaushaltID(id: Int): LiveData<List<Urlaub>> {
+        return repo.getAllUrlaubByHaushaltID(id)
     }
 
     fun insertHaushalt(a: Haushalt) {

--- a/app/src/main/res/layout/fragment_haushalt_bearbeiten_loeschen.xml
+++ b/app/src/main/res/layout/fragment_haushalt_bearbeiten_loeschen.xml
@@ -1,270 +1,266 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
-    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    tools:context=".ui.haushalt.haushalteBearbeiten_Loeschen.HaushaltBearbeitenLoeschenFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:fillViewport="true"
-        tools:context=".ui.haushalt.haushalteBearbeiten_Loeschen.HaushaltBearbeitenLoeschenFragment">
+        android:layout_height="wrap_content">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_datum_akt_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/content_margin_top_small"
+            android:hint="@string/haushaltedithint_datum"
+            app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_datum_akt"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_datum_akt" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_datum_akt_value"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/content_margin_top_small"
-                android:hint="@string/haushaltedithint_datum"
-                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_datum_akt"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_datum_akt" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_datum_akt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/haushaltdatum"
+            app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
+            app:layout_constraintTop_toTopOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_datum_akt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/haushaltdatum"
-                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
-                app:layout_constraintTop_toTopOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt" />
-
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/content_margin_sides_normal"
-                android:layout_marginTop="@dimen/content_margin_top"
-                android:ems="10"
-                android:text="@string/haushaltsname"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/content_margin_sides_normal"
+            android:layout_marginTop="@dimen/content_margin_top"
+            android:ems="10"
+            android:text="@string/haushaltsname"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
 
-            <EditText
-                android:id="@+id/edit_text_haushalt_bearbeiten_name"
-                android:layout_width="wrap_content"
-                android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginTop="@dimen/content_margin_top_small"
-                android:autofillHints="@string/haushaltedithint_name"
-                android:hint="@string/haushaltedithint_name"
-                android:inputType="textPersonName"
-                android:maxLength="30"
-                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_name"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_name" />
+        <EditText
+            android:id="@+id/edit_text_haushalt_bearbeiten_name"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/haushalt_edit_text_height"
+            android:layout_marginTop="@dimen/content_margin_top_small"
+            android:autofillHints="@string/haushaltedithint_name"
+            android:hint="@string/haushaltedithint_name"
+            android:inputType="textPersonName"
+            android:maxLength="30"
+            app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_name"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_name" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_strompreis"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:text="@string/haushaltstrompreis"
-                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_name"
-                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_name" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_strompreis"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+            android:text="@string/haushaltstrompreis"
+            app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_name"
+            app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_name" />
 
-            <EditText
-                android:id="@+id/edit_text_haushalt_bearbeiten_strompreis"
-                android:layout_width="@dimen/haushalt_edit_text_width"
-                android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginTop="@dimen/content_margin_top_small"
-                android:autofillHints="@string/haushaltedithint_strompreis"
-                android:hint="@string/haushaltedithint_strompreis"
-                android:inputType="numberDecimal"
-                android:maxLength="6"
-                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_strompreis"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_strompreis" />
+        <EditText
+            android:id="@+id/edit_text_haushalt_bearbeiten_strompreis"
+            android:layout_width="@dimen/haushalt_edit_text_width"
+            android:layout_height="@dimen/haushalt_edit_text_height"
+            android:layout_marginTop="@dimen/content_margin_top_small"
+            android:autofillHints="@string/haushaltedithint_strompreis"
+            android:hint="@string/haushaltedithint_strompreis"
+            android:inputType="numberDecimal"
+            android:maxLength="6"
+            app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_strompreis"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_strompreis" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_strompreis_einheit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/margin_edit_and_text_one_line"
-                android:text="@string/Einheit_Cent"
-                android:textAlignment="center"
-                android:textSize="15sp"
-                app:layout_constraintStart_toEndOf="@id/edit_text_haushalt_bearbeiten_strompreis"
-                app:layout_constraintTop_toTopOf="@+id/edit_text_haushalt_bearbeiten_strompreis" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_strompreis_einheit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/margin_edit_and_text_one_line"
+            android:text="@string/Einheit_Cent"
+            android:textAlignment="center"
+            android:textSize="15sp"
+            app:layout_constraintStart_toEndOf="@id/edit_text_haushalt_bearbeiten_strompreis"
+            app:layout_constraintTop_toTopOf="@+id/edit_text_haushalt_bearbeiten_strompreis" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_anzahl_personen"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:text="@string/haushaltspersonen"
-                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_strompreis"
-                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_strompreis" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_anzahl_personen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+            android:text="@string/haushaltspersonen"
+            app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_strompreis"
+            app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_strompreis" />
 
-            <EditText
-                android:id="@+id/edit_text_haushalt_bearbeiten_anzahl_personen"
-                android:layout_width="@dimen/haushalt_edit_text_width"
-                android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginTop="@dimen/content_margin_top_small"
-                android:autofillHints="@string/haushaltedithint_personen"
-                android:hint="@string/haushaltedithint_personen"
-                android:inputType="number"
-                android:maxLength="3"
-                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_anzahl_personen"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_anzahl_personen" />
+        <EditText
+            android:id="@+id/edit_text_haushalt_bearbeiten_anzahl_personen"
+            android:layout_width="@dimen/haushalt_edit_text_width"
+            android:layout_height="@dimen/haushalt_edit_text_height"
+            android:layout_marginTop="@dimen/content_margin_top_small"
+            android:autofillHints="@string/haushaltedithint_personen"
+            android:hint="@string/haushaltedithint_personen"
+            android:inputType="number"
+            android:maxLength="3"
+            app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_anzahl_personen"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_anzahl_personen" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:text="@string/haushalt_zaehlerstand_neu"
-                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_anzahl_personen"
-                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_anzahl_personen" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+            android:text="@string/haushalt_zaehlerstand_neu"
+            app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_anzahl_personen"
+            app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_anzahl_personen" />
 
-            <EditText
-                android:id="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
-                android:layout_width="@dimen/edit_num_len_six"
-                android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginTop="@dimen/content_margin_top_small"
-                android:autofillHints="@string/haushaltedithint_stand"
-                android:hint="@string/haushaltedithint_stand"
-                android:inputType="numberDecimal"
-                android:maxLength="16"
-                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu" />
+        <EditText
+            android:id="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
+            android:layout_width="@dimen/edit_num_len_six"
+            android:layout_height="@dimen/haushalt_edit_text_height"
+            android:layout_marginTop="@dimen/content_margin_top_small"
+            android:autofillHints="@string/haushaltedithint_stand"
+            android:hint="@string/haushaltedithint_stand"
+            android:inputType="numberDecimal"
+            android:maxLength="16"
+            app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_zählerstand_einheit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/margin_edit_and_text_one_line"
-                android:text="@string/Einheit_kWh"
-                android:textAlignment="center"
-                android:textSize="15sp"
-                app:layout_constraintStart_toEndOf="@id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
-                app:layout_constraintTop_toTopOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_zählerstand_einheit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/margin_edit_and_text_one_line"
+            android:text="@string/Einheit_kWh"
+            android:textAlignment="center"
+            android:textSize="15sp"
+            app:layout_constraintStart_toEndOf="@id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
+            app:layout_constraintTop_toTopOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_datum_neu"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/haushaltdatum"
-                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
-                app:layout_constraintTop_toTopOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_datum_neu"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/haushaltdatum"
+            app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
+            app:layout_constraintTop_toTopOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu" />
 
-            <EditText
-                android:id="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
-                android:layout_width="@dimen/edit_date_width"
-                android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginStart="@dimen/haushalt_margin_column"
-                android:layout_marginTop="@dimen/content_margin_top_small"
-                android:layout_marginEnd="@dimen/content_margin_sides_normal"
-                android:autofillHints="@string/haushaltedithint_datum"
-                android:hint="@string/haushaltedithint_datum"
-                android:inputType="date"
-                android:maxLength="10"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/text_view_haushalt_bearbeiten_zählerstand_einheit"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_datum_neu" />
+        <EditText
+            android:id="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
+            android:layout_width="@dimen/edit_date_width"
+            android:layout_height="@dimen/haushalt_edit_text_height"
+            android:layout_marginStart="@dimen/haushalt_margin_column"
+            android:layout_marginTop="@dimen/content_margin_top_small"
+            android:layout_marginEnd="@dimen/content_margin_sides_normal"
+            android:autofillHints="@string/haushaltedithint_datum"
+            android:hint="@string/haushaltedithint_datum"
+            android:inputType="date"
+            android:maxLength="10"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/text_view_haushalt_bearbeiten_zählerstand_einheit"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_datum_neu" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_oekostrom"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_row_text_and_checkbox"
-                android:text="@string/haushaltökomix"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/check_box_haushalt_bearbeiten_oekostrom" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_oekostrom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/haushalt_margin_start"
+            android:layout_marginTop="@dimen/haushalt_margin_row_text_and_checkbox"
+            android:text="@string/haushaltökomix"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/check_box_haushalt_bearbeiten_oekostrom" />
 
-            <CheckBox
-                android:id="@+id/check_box_haushalt_bearbeiten_oekostrom"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/content_margin_sides_normal"
-                android:layout_marginTop="@dimen/content_margin_top"
-                android:autofillHints="@string/haushaltedithint_strommix"
-                android:hint="@string/haushaltedithint_strommix"
-                app:layout_constraintStart_toEndOf="@+id/text_view_haushalt_bearbeiten_oekostrom"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_auswertung" />
+        <CheckBox
+            android:id="@+id/check_box_haushalt_bearbeiten_oekostrom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/content_margin_sides_normal"
+            android:layout_marginTop="@dimen/content_margin_top"
+            android:autofillHints="@string/haushaltedithint_strommix"
+            android:hint="@string/haushaltedithint_strommix"
+            app:layout_constraintStart_toEndOf="@+id/text_view_haushalt_bearbeiten_oekostrom"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_auswertung" />
 
-            <Button
-                android:id="@+id/button_haushalt_bearbeiten_speichern"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:layout_marginEnd="32dp"
-                android:layout_marginBottom="16dp"
-                android:background="@color/colorPrimary"
-                android:text="@string/button_speichern"
-                android:textColor="@color/colorWhite"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_oekostrom"
-                app:layout_constraintVertical_bias="1.0" />
+        <Button
+            android:id="@+id/button_haushalt_bearbeiten_speichern"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            android:background="@color/colorPrimary"
+            android:text="@string/button_speichern"
+            android:textColor="@color/colorWhite"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_oekostrom"
+            app:layout_constraintVertical_bias="1.0" />
 
-            <Button
-                android:id="@+id/button_haushalt_bearbeiten_loeschen"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="35dp"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:layout_marginEnd="32dp"
-                android:layout_marginBottom="16dp"
-                android:background="@color/colorDarkRed"
-                android:text="@string/button_loeschen"
-                android:textColor="@color/colorWhite"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom"
-                app:layout_constraintVertical_bias="1.0" />
+        <Button
+            android:id="@+id/button_haushalt_bearbeiten_loeschen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="35dp"
+            android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            android:background="@color/colorDarkRed"
+            android:text="@string/button_loeschen"
+            android:textColor="@color/colorWhite"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom"
+            app:layout_constraintVertical_bias="1.0" />
 
-            <Button
-                android:id="@+id/button_haushalt_bearbeiten_abbrechen"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="32dp"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:layout_marginBottom="16dp"
-                android:background="@color/colorDarkGreen"
-                android:text="@string/button_abbrechen"
-                android:textColor="@color/colorWhite"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom"
-                app:layout_constraintVertical_bias="1.0" />
+        <Button
+            android:id="@+id/button_haushalt_bearbeiten_abbrechen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+            android:layout_marginBottom="16dp"
+            android:background="@color/colorDarkGreen"
+            android:text="@string/button_abbrechen"
+            android:textColor="@color/colorWhite"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom"
+            app:layout_constraintVertical_bias="1.0" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:text="@string/haushaltzaehlerstand"
-                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
-                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+            android:text="@string/haushaltzaehlerstand"
+            app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
+            app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/content_margin_top_small"
-                android:hint="@string/haushalt_zaehlerstand_placeholder"
-                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/content_margin_top_small"
+            android:hint="@string/haushalt_zaehlerstand_placeholder"
+            app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt" />
 
-            <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_auswertung"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/content_margin_top"
-                android:layout_marginEnd="@dimen/content_margin_sides_normal"
-                android:hint="@string/haushalt_hint_auswertung"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value" />
+        <TextView
+            android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_auswertung"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/content_margin_top"
+            android:layout_marginEnd="@dimen/content_margin_sides_normal"
+            android:hint="@string/haushalt_hint_auswertung"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value"
+            app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </ScrollView>
-
-
-
-
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_haushalt_bearbeiten_loeschen.xml
+++ b/app/src/main/res/layout/fragment_haushalt_bearbeiten_loeschen.xml
@@ -12,12 +12,30 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/text_view_haushalt_bearbeiten_datum_akt_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/content_margin_top_small"
+                android:hint="@string/haushaltedithint_datum"
+                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_datum_akt"
+                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_datum_akt" />
+
+            <TextView
+                android:id="@+id/text_view_haushalt_bearbeiten_datum_akt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/haushaltdatum"
+                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
+                app:layout_constraintTop_toTopOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt" />
+
             <TextView
                 android:id="@+id/text_view_haushalt_bearbeiten_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+                android:layout_marginStart="@dimen/content_margin_sides_normal"
+                android:layout_marginTop="@dimen/content_margin_top"
                 android:ems="10"
                 android:text="@string/haushaltsname"
                 app:layout_constraintStart_toStartOf="parent"
@@ -28,36 +46,33 @@
                 android:id="@+id/edit_text_haushalt_bearbeiten_name"
                 android:layout_width="wrap_content"
                 android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_klein"
-                android:maxLength="30"
+                android:layout_marginTop="@dimen/content_margin_top_small"
                 android:autofillHints="@string/haushaltedithint_name"
                 android:hint="@string/haushaltedithint_name"
                 android:inputType="textPersonName"
-                app:layout_constraintStart_toStartOf="parent"
+                android:maxLength="30"
+                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_name"
                 app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_name" />
 
             <TextView
                 android:id="@+id/text_view_haushalt_bearbeiten_strompreis"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
                 android:layout_marginTop="@dimen/haushalt_margin_top_groß"
                 android:text="@string/haushaltstrompreis"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_name"
                 app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_name" />
 
             <EditText
                 android:id="@+id/edit_text_haushalt_bearbeiten_strompreis"
                 android:layout_width="@dimen/haushalt_edit_text_width"
                 android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_klein"
-                android:hint="@string/haushaltedithint_strompreis"
-                android:maxLength="6"
+                android:layout_marginTop="@dimen/content_margin_top_small"
                 android:autofillHints="@string/haushaltedithint_strompreis"
+                android:hint="@string/haushaltedithint_strompreis"
                 android:inputType="numberDecimal"
-                app:layout_constraintStart_toStartOf="parent"
+                android:maxLength="6"
+                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_strompreis"
                 app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_strompreis" />
 
             <TextView
@@ -65,114 +80,110 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/verbrauchsrechner_marginTopEinheiten"
+                android:layout_marginTop="@dimen/margin_edit_and_text_one_line"
                 android:text="@string/Einheit_Cent"
                 android:textAlignment="center"
                 android:textSize="15sp"
                 app:layout_constraintStart_toEndOf="@id/edit_text_haushalt_bearbeiten_strompreis"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_strompreis" />
+                app:layout_constraintTop_toTopOf="@+id/edit_text_haushalt_bearbeiten_strompreis" />
 
             <TextView
                 android:id="@+id/text_view_haushalt_bearbeiten_anzahl_personen"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
                 android:layout_marginTop="@dimen/haushalt_margin_top_groß"
                 android:text="@string/haushaltspersonen"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_strompreis"
                 app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_strompreis" />
 
             <EditText
                 android:id="@+id/edit_text_haushalt_bearbeiten_anzahl_personen"
                 android:layout_width="@dimen/haushalt_edit_text_width"
                 android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_klein"
+                android:layout_marginTop="@dimen/content_margin_top_small"
+                android:autofillHints="@string/haushaltedithint_personen"
+                android:hint="@string/haushaltedithint_personen"
                 android:inputType="number"
                 android:maxLength="3"
-                android:hint="@string/haushaltedithint_personen"
-                android:autofillHints="@string/haushaltedithint_personen"
-                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_anzahl_personen"
                 app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_anzahl_personen" />
 
             <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand"
+                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
                 android:layout_marginTop="@dimen/haushalt_margin_top_groß"
-                android:text="@string/haushaltzaehlerstand"
-                app:layout_constraintStart_toStartOf="parent"
+                android:text="@string/haushalt_zaehlerstand_neu"
+                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_anzahl_personen"
                 app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_anzahl_personen" />
 
             <EditText
-                android:id="@+id/edit_text_haushalt_bearbeiten_zaehlerstand"
-                android:layout_width="@dimen/haushalt_edit_text_width"
+                android:id="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
+                android:layout_width="@dimen/edit_num_len_six"
                 android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_klein"
-                android:hint="@string/haushaltedithint_stand"
-                android:maxLength="16"
+                android:layout_marginTop="@dimen/content_margin_top_small"
                 android:autofillHints="@string/haushaltedithint_stand"
+                android:hint="@string/haushaltedithint_stand"
                 android:inputType="numberDecimal"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand" />
+                android:maxLength="16"
+                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu"
+                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu" />
 
             <TextView
                 android:id="@+id/text_view_haushalt_bearbeiten_zählerstand_einheit"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
-                android:layout_marginTop="@dimen/verbrauchsrechner_marginTopEinheiten"
+                android:layout_marginTop="@dimen/margin_edit_and_text_one_line"
                 android:text="@string/Einheit_kWh"
                 android:textAlignment="center"
                 android:textSize="15sp"
-                app:layout_constraintStart_toEndOf="@id/edit_text_haushalt_bearbeiten_zaehlerstand"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand" />
+                app:layout_constraintStart_toEndOf="@id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
+                app:layout_constraintTop_toTopOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value" />
 
             <TextView
-                android:id="@+id/text_view_haushalt_bearbeiten_datum"
+                android:id="@+id/text_view_haushalt_bearbeiten_datum_neu"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
                 android:text="@string/haushaltdatum"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand" />
+                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
+                app:layout_constraintTop_toTopOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_neu" />
 
             <EditText
-                android:id="@+id/edit_text_haushalt_bearbeiten_datum"
-                android:layout_width="@dimen/haushalt_edit_text_width"
+                android:id="@+id/edit_text_haushalt_bearbeiten_datum_neu_value"
+                android:layout_width="@dimen/edit_date_width"
                 android:layout_height="@dimen/haushalt_edit_text_height"
-                android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_klein"
-                android:hint="@string/haushaltedithint_datum"
-                android:maxLength="10"
+                android:layout_marginStart="@dimen/haushalt_margin_column"
+                android:layout_marginTop="@dimen/content_margin_top_small"
+                android:layout_marginEnd="@dimen/content_margin_sides_normal"
                 android:autofillHints="@string/haushaltedithint_datum"
+                android:hint="@string/haushaltedithint_datum"
                 android:inputType="date"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_datum" />
+                android:maxLength="10"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/text_view_haushalt_bearbeiten_zählerstand_einheit"
+                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_datum_neu" />
 
             <TextView
                 android:id="@+id/text_view_haushalt_bearbeiten_oekostrom"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/haushalt_margin_start"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+                android:layout_marginTop="@dimen/haushalt_margin_row_text_and_checkbox"
                 android:text="@string/haushaltökomix"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_datum" />
+                app:layout_constraintTop_toTopOf="@+id/check_box_haushalt_bearbeiten_oekostrom" />
 
             <CheckBox
                 android:id="@+id/check_box_haushalt_bearbeiten_oekostrom"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="12dp"
-                android:layout_marginTop="25dp"
+                android:layout_marginStart="@dimen/content_margin_sides_normal"
+                android:layout_marginTop="@dimen/content_margin_top"
                 android:autofillHints="@string/haushaltedithint_strommix"
                 android:hint="@string/haushaltedithint_strommix"
                 app:layout_constraintStart_toEndOf="@+id/text_view_haushalt_bearbeiten_oekostrom"
-                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_datum" />
+                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_auswertung" />
 
             <Button
                 android:id="@+id/button_haushalt_bearbeiten_speichern"
@@ -186,23 +197,25 @@
                 android:textColor="@color/colorWhite"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_oekostrom" />
+                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_oekostrom"
+                app:layout_constraintVertical_bias="1.0" />
 
             <Button
                 android:id="@+id/button_haushalt_bearbeiten_loeschen"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="35dp"
+                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
                 android:layout_marginEnd="32dp"
                 android:layout_marginBottom="16dp"
-                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
                 android:background="@color/colorDarkRed"
                 android:text="@string/button_loeschen"
                 android:textColor="@color/colorWhite"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom" />
+                app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom"
+                app:layout_constraintVertical_bias="1.0" />
 
             <Button
                 android:id="@+id/button_haushalt_bearbeiten_abbrechen"
@@ -216,7 +229,38 @@
                 android:textColor="@color/colorWhite"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom" />
+                app:layout_constraintTop_toBottomOf="@+id/check_box_haushalt_bearbeiten_oekostrom"
+                app:layout_constraintVertical_bias="1.0" />
+
+            <TextView
+                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/haushalt_margin_top_groß"
+                android:text="@string/haushaltzaehlerstand"
+                app:layout_constraintStart_toStartOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value"
+                app:layout_constraintTop_toBottomOf="@+id/edit_text_haushalt_bearbeiten_zaehlerstand_neu_value" />
+
+            <TextView
+                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/content_margin_top_small"
+                android:hint="@string/haushalt_zaehlerstand_placeholder"
+                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt"
+                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt" />
+
+            <TextView
+                android:id="@+id/text_view_haushalt_bearbeiten_zaehlerstand_auswertung"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/content_margin_top"
+                android:layout_marginEnd="@dimen/content_margin_sides_normal"
+                android:hint="@string/haushalt_hint_auswertung"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value"
+                app:layout_constraintTop_toBottomOf="@+id/text_view_haushalt_bearbeiten_zaehlerstand_akt_value" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -59,16 +59,22 @@
     <dimen name="haushalt_margin_top_klein">20dp</dimen>
     <dimen name="haushalt_edit_text_width">160dp</dimen>
     <dimen name="haushalt_edit_text_height">45dp</dimen>
-
+    <dimen name="haushalt_margin_column">64dp</dimen>
+    <dimen name="haushalt_margin_row_text_and_checkbox">8dp</dimen>
     <dimen name="urlaub_margin_recycler_name">16dp</dimen>
 
     <dimen name="content_margin_top">16dp</dimen>
+    <dimen name="content_margin_top_small">8dp</dimen>
     <dimen name="content_margin_sides_small">8dp</dimen>
     <dimen name="content_margin_sides_normal">16dp</dimen>
     <dimen name="content_margin_bottom">16dp</dimen>
     <dimen name="button_margin_between">16dp</dimen>
     <dimen name="card_view_margin">8dp</dimen>
-    <dimen name="edit_name_width_long">250dp</dimen>
+    <dimen name="margin_edit_and_text_one_line">14dp</dimen>
     <dimen name="margin_bottom_because_fab">77dp</dimen>
+
+    <dimen name="edit_name_width_long">250dp</dimen>
+    <dimen name="edit_date_width">115dp</dimen>
+    <dimen name="edit_num_len_six">85dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,9 +45,12 @@
     <string name="haushaltspersonen">Anzahl Personen</string>
     <string name="haushaltdatum">Datum</string>
     <string name="haushaltzaehlerstand">Aktueller Zählerstand</string>
+    <string name="haushalt_zaehlerstand_neu">Neuer Zählerstand</string>
+    <string name="haushalt_zaehlerstand_placeholder">X kWh</string>
+    <string name="haushalt_hint_auswertung">Die eingegebenen Werte für Zählerstand und Datum sind ungültig. Deswegen wird der bisherige Zählerstand gespeichert.</string>
     <string name="haushaltökomix">Ökomix?</string>
     <string name="haushaltedithint_name">z.B. Haushalt</string>
-    <string name="haushaltedithint_strompreis">z.B. 26,62</string>
+    <string name="haushaltedithint_strompreis">z.B. 26.62</string>
     <string name="haushaltedithint_personen">z.B. 2</string>
     <string name="haushaltedithint_stand">z.B. 2500</string>
     <string name="haushaltedithint_datum">DD.MM.JJJJ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,15 +193,11 @@
         Austausch und Montage, Lebensdauer, Zinsen und der Wiederverkaufswert des aktuellen Gerätes berücksichtigt werden.</string>
     <string name="amort_hint_amortdauer">X Jahre und X Tage bis zur Amortisation.</string>
     <string name="amort_hint_amort_ersparnis">Danach: X Euro Ersparnis im Jahr.</string>
-    
+
     <string name="geraet_new_prod_hint_prod">z.B 2700</string>
     <string name="geraet_prod_edit_hint_verbrauch">z.B 30</string>
 
     <string name="parse_error_datum">Datum konnte nicht geparsed werden, achten Sie auf das Format: dd.MM.yyyy</string>
-
-
-
-
 
     <string name="urlaub_hint_haushalt">Haushalt X</string>
     <string name="urlaub_text_name">Name des Urlaubs</string>


### PR DESCRIPTION
Man kann beim Editieren eines Haushaltes nun den bisherigen Zählerstand in einer TextView sehen.
Den neuen kann man durch ein EditText eingeben, dann wird automatisch die Differenz in Tagen und in kWh ausgerechnet.
Falls der Zählerstand kleiner wurde oder das Datum vor dem bisherigen liegt, wird der bisherige Wert gespeichert und der neue verworfen. Das bekommt der Nutzer auch angezeigt.
Die Differenz der Zählerstände wird nun mit dem geschätzen Verbrauch durch die eingetragenen Verbraucher, Produzenten und Urlaube berechnet.